### PR TITLE
Update for Stardew Valley 1.3.31

### DIFF
--- a/AnimalSitter/AnimalSitter.csproj
+++ b/AnimalSitter/AnimalSitter.csproj
@@ -30,7 +30,7 @@
     <WarningLevel>4</WarningLevel>
   </PropertyGroup>
   <ItemGroup>
-    <PackageReference Include="Pathoschild.Stardew.ModBuildConfig" Version="2.1.0-beta-20180426" />
+    <PackageReference Include="Pathoschild.Stardew.ModBuildConfig" Version="2.2.0" />
   </ItemGroup>
   <ItemGroup>
     <Reference Include="System" />

--- a/AnimalSitter/AnimalSitter.csproj
+++ b/AnimalSitter/AnimalSitter.csproj
@@ -1,5 +1,5 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
-<Project ToolsVersion="14.0" DefaultTargets="Build" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
+<Project ToolsVersion="15.0" DefaultTargets="Build" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
   <Import Project="$(MSBuildExtensionsPath)\$(MSBuildToolsVersion)\Microsoft.Common.props" Condition="Exists('$(MSBuildExtensionsPath)\$(MSBuildToolsVersion)\Microsoft.Common.props')" />
   <PropertyGroup>
     <Configuration Condition=" '$(Configuration)' == '' ">Debug</Configuration>
@@ -30,6 +30,9 @@
     <WarningLevel>4</WarningLevel>
   </PropertyGroup>
   <ItemGroup>
+    <PackageReference Include="Pathoschild.Stardew.ModBuildConfig" Version="2.1.0-beta-20180426" />
+  </ItemGroup>
+  <ItemGroup>
     <Reference Include="System" />
     <Reference Include="System.Xml" />
   </ItemGroup>
@@ -47,18 +50,7 @@
       <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
     </None>
     <None Include="manifest.json" />
-    <None Include="packages.config" />
-  </ItemGroup>
-  <ItemGroup>
-    <Analyzer Include="..\packages\Pathoschild.Stardew.ModBuildConfig.2.1.0-beta-20180426\analyzers\dotnet\cs\StardewModdingAPI.ModBuildConfig.Analyzer.dll" />
   </ItemGroup>
   <Import Project="..\Common\Common.projitems" Label="Shared" />
   <Import Project="$(MSBuildToolsPath)\Microsoft.CSharp.targets" />
-  <Import Project="..\packages\Pathoschild.Stardew.ModBuildConfig.2.1.0-beta-20180426\build\Pathoschild.Stardew.ModBuildConfig.targets" Condition="Exists('..\packages\Pathoschild.Stardew.ModBuildConfig.2.1.0-beta-20180426\build\Pathoschild.Stardew.ModBuildConfig.targets')" />
-  <Target Name="EnsureNuGetPackageBuildImports" BeforeTargets="PrepareForBuild">
-    <PropertyGroup>
-      <ErrorText>This project references NuGet package(s) that are missing on this computer. Use NuGet Package Restore to download them.  For more information, see http://go.microsoft.com/fwlink/?LinkID=322105. The missing file is {0}.</ErrorText>
-    </PropertyGroup>
-    <Error Condition="!Exists('..\packages\Pathoschild.Stardew.ModBuildConfig.2.1.0-beta-20180426\build\Pathoschild.Stardew.ModBuildConfig.targets')" Text="$([System.String]::Format('$(ErrorText)', '..\packages\Pathoschild.Stardew.ModBuildConfig.2.1.0-beta-20180426\build\Pathoschild.Stardew.ModBuildConfig.targets'))" />
-  </Target>
 </Project>

--- a/AnimalSitter/manifest.json
+++ b/AnimalSitter/manifest.json
@@ -1,10 +1,10 @@
 ﻿{
   "Name": "Animal Sitter",
   "Author": "jwdred",
-  "Version": "1.1.0",
+  "Version": "1.1.1",
   "Description": "Let someone else pet all those pesky animals!",
   "UniqueID": "jwdred.AnimalSitter",
   "EntryDll": "AnimalSitter.dll",
-  "MinimumApiVersion": "2.6-beta",
+  "MinimumApiVersion": "2.8-beta",
   "UpdateKeys": [ "Nexus:581" ]
 }

--- a/AnimalSitter/packages.config
+++ b/AnimalSitter/packages.config
@@ -1,4 +1,0 @@
-﻿<?xml version="1.0" encoding="utf-8"?>
-<packages>
-  <package id="Pathoschild.Stardew.ModBuildConfig" version="2.1.0-beta-20180426" targetFramework="net452" />
-</packages>

--- a/Common/DialogueManager.cs
+++ b/Common/DialogueManager.cs
@@ -51,10 +51,7 @@ namespace StardewLib
 
         public string GetRandomMessage(string messageStoreName)
         {
-            string value = "";
-
-            Dictionary<int, string> messagePool = null;
-            this.DialogueLookups.TryGetValue(messageStoreName, out messagePool);
+            this.DialogueLookups.TryGetValue(messageStoreName, out Dictionary<int, string> messagePool);
 
             if (messagePool == null)
             {
@@ -66,7 +63,7 @@ namespace StardewLib
             }
 
             int rand = this.Random.Next(1, messagePool.Count + 1);
-            messagePool.TryGetValue(rand, out value);
+            messagePool.TryGetValue(rand, out string value);
 
             if (value == null)
             {
@@ -80,8 +77,7 @@ namespace StardewLib
 
         public string GetMessageAt(int index, string messageStoreName)
         {
-            Dictionary<int, string> messagePool = null;
-            this.DialogueLookups.TryGetValue(messageStoreName, out messagePool);
+            this.DialogueLookups.TryGetValue(messageStoreName, out Dictionary<int, string> messagePool);
 
             if (messagePool == null)
             {

--- a/CrabNet/CrabNet.cs
+++ b/CrabNet/CrabNet.cs
@@ -459,9 +459,7 @@ namespace CrabNet
         {
             int rand = this.Random.Next(1, messageStore.Count + 1);
 
-            string value = "...$h#$e#";
-
-            messageStore.TryGetValue(rand, out value);
+            messageStore.TryGetValue(rand, out string value);
 
             if (this.LoggingEnabled)
                 this.Monitor.Log($"condition met to return random unfinished message, returning:{value}", LogLevel.Trace);

--- a/CrabNet/CrabNet.csproj
+++ b/CrabNet/CrabNet.csproj
@@ -30,7 +30,7 @@
     <WarningLevel>4</WarningLevel>
   </PropertyGroup>
   <ItemGroup>
-    <PackageReference Include="Pathoschild.Stardew.ModBuildConfig" Version="2.1.0-beta-20180426" />
+    <PackageReference Include="Pathoschild.Stardew.ModBuildConfig" Version="2.2.0" />
   </ItemGroup>
   <ItemGroup>
     <Reference Include="System" />

--- a/CrabNet/CrabNet.csproj
+++ b/CrabNet/CrabNet.csproj
@@ -1,5 +1,5 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
-<Project ToolsVersion="14.0" DefaultTargets="Build" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
+<Project ToolsVersion="15.0" DefaultTargets="Build" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
   <Import Project="$(MSBuildExtensionsPath)\$(MSBuildToolsVersion)\Microsoft.Common.props" Condition="Exists('$(MSBuildExtensionsPath)\$(MSBuildToolsVersion)\Microsoft.Common.props')" />
   <PropertyGroup>
     <Configuration Condition=" '$(Configuration)' == '' ">Debug</Configuration>
@@ -30,6 +30,9 @@
     <WarningLevel>4</WarningLevel>
   </PropertyGroup>
   <ItemGroup>
+    <PackageReference Include="Pathoschild.Stardew.ModBuildConfig" Version="2.1.0-beta-20180426" />
+  </ItemGroup>
+  <ItemGroup>
     <Reference Include="System" />
     <Reference Include="System.Xml" />
   </ItemGroup>
@@ -47,18 +50,7 @@
       <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
     </None>
     <None Include="manifest.json" />
-    <None Include="packages.config" />
-  </ItemGroup>
-  <ItemGroup>
-    <Analyzer Include="..\packages\Pathoschild.Stardew.ModBuildConfig.2.1.0-beta-20180426\analyzers\dotnet\cs\StardewModdingAPI.ModBuildConfig.Analyzer.dll" />
   </ItemGroup>
   <Import Project="..\Common\Common.projitems" Label="Shared" />
   <Import Project="$(MSBuildToolsPath)\Microsoft.CSharp.targets" />
-  <Import Project="..\packages\Pathoschild.Stardew.ModBuildConfig.2.1.0-beta-20180426\build\Pathoschild.Stardew.ModBuildConfig.targets" Condition="Exists('..\packages\Pathoschild.Stardew.ModBuildConfig.2.1.0-beta-20180426\build\Pathoschild.Stardew.ModBuildConfig.targets')" />
-  <Target Name="EnsureNuGetPackageBuildImports" BeforeTargets="PrepareForBuild">
-    <PropertyGroup>
-      <ErrorText>This project references NuGet package(s) that are missing on this computer. Use NuGet Package Restore to download them.  For more information, see http://go.microsoft.com/fwlink/?LinkID=322105. The missing file is {0}.</ErrorText>
-    </PropertyGroup>
-    <Error Condition="!Exists('..\packages\Pathoschild.Stardew.ModBuildConfig.2.1.0-beta-20180426\build\Pathoschild.Stardew.ModBuildConfig.targets')" Text="$([System.String]::Format('$(ErrorText)', '..\packages\Pathoschild.Stardew.ModBuildConfig.2.1.0-beta-20180426\build\Pathoschild.Stardew.ModBuildConfig.targets'))" />
-  </Target>
 </Project>

--- a/CrabNet/manifest.json
+++ b/CrabNet/manifest.json
@@ -1,10 +1,10 @@
 ﻿{
   "Name": "Crab Net",
   "Author": "jwdred",
-  "Version": "1.1.0",
+  "Version": "1.1.1",
   "Description": "Wouldn't it be nice if there were a way to empty crab pots quickly without accidentally picking up the pot too?",
   "UniqueID": "jwdred.CrabNet",
   "EntryDll": "CrabNet.dll",
-  "MinimumApiVersion": "2.6-beta",
+  "MinimumApiVersion": "2.8-beta",
   "UpdateKeys": [ "Nexus:584" ]
 }

--- a/CrabNet/packages.config
+++ b/CrabNet/packages.config
@@ -1,4 +1,0 @@
-﻿<?xml version="1.0" encoding="utf-8"?>
-<packages>
-  <package id="Pathoschild.Stardew.ModBuildConfig" version="2.1.0-beta-20180426" targetFramework="net452" />
-</packages>

--- a/MailOrderPigs/MailOrderPigs.csproj
+++ b/MailOrderPigs/MailOrderPigs.csproj
@@ -1,5 +1,5 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
-<Project ToolsVersion="14.0" DefaultTargets="Build" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
+<Project ToolsVersion="15.0" DefaultTargets="Build" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
   <Import Project="$(MSBuildExtensionsPath)\$(MSBuildToolsVersion)\Microsoft.Common.props" Condition="Exists('$(MSBuildExtensionsPath)\$(MSBuildToolsVersion)\Microsoft.Common.props')" />
   <PropertyGroup>
     <Configuration Condition=" '$(Configuration)' == '' ">Debug</Configuration>
@@ -30,6 +30,9 @@
     <WarningLevel>4</WarningLevel>
   </PropertyGroup>
   <ItemGroup>
+    <PackageReference Include="Pathoschild.Stardew.ModBuildConfig" Version="2.1.0-beta-20180426" />
+  </ItemGroup>
+  <ItemGroup>
     <Reference Include="System" />
     <Reference Include="System.Xml" />
   </ItemGroup>
@@ -41,18 +44,7 @@
   </ItemGroup>
   <ItemGroup>
     <None Include="manifest.json" />
-    <None Include="packages.config" />
-  </ItemGroup>
-  <ItemGroup>
-    <Analyzer Include="..\packages\Pathoschild.Stardew.ModBuildConfig.2.1.0-beta-20180426\analyzers\dotnet\cs\StardewModdingAPI.ModBuildConfig.Analyzer.dll" />
   </ItemGroup>
   <Import Project="..\Common\Common.projitems" Label="Shared" />
   <Import Project="$(MSBuildToolsPath)\Microsoft.CSharp.targets" />
-  <Import Project="..\packages\Pathoschild.Stardew.ModBuildConfig.2.1.0-beta-20180426\build\Pathoschild.Stardew.ModBuildConfig.targets" Condition="Exists('..\packages\Pathoschild.Stardew.ModBuildConfig.2.1.0-beta-20180426\build\Pathoschild.Stardew.ModBuildConfig.targets')" />
-  <Target Name="EnsureNuGetPackageBuildImports" BeforeTargets="PrepareForBuild">
-    <PropertyGroup>
-      <ErrorText>This project references NuGet package(s) that are missing on this computer. Use NuGet Package Restore to download them.  For more information, see http://go.microsoft.com/fwlink/?LinkID=322105. The missing file is {0}.</ErrorText>
-    </PropertyGroup>
-    <Error Condition="!Exists('..\packages\Pathoschild.Stardew.ModBuildConfig.2.1.0-beta-20180426\build\Pathoschild.Stardew.ModBuildConfig.targets')" Text="$([System.String]::Format('$(ErrorText)', '..\packages\Pathoschild.Stardew.ModBuildConfig.2.1.0-beta-20180426\build\Pathoschild.Stardew.ModBuildConfig.targets'))" />
-  </Target>
 </Project>

--- a/MailOrderPigs/MailOrderPigs.csproj
+++ b/MailOrderPigs/MailOrderPigs.csproj
@@ -30,7 +30,7 @@
     <WarningLevel>4</WarningLevel>
   </PropertyGroup>
   <ItemGroup>
-    <PackageReference Include="Pathoschild.Stardew.ModBuildConfig" Version="2.1.0-beta-20180426" />
+    <PackageReference Include="Pathoschild.Stardew.ModBuildConfig" Version="2.2.0" />
   </ItemGroup>
   <ItemGroup>
     <Reference Include="System" />

--- a/MailOrderPigs/manifest.json
+++ b/MailOrderPigs/manifest.json
@@ -1,10 +1,10 @@
 ﻿{
   "Name": "Mail Order Pigs",
   "Author": "jwdred",
-  "Version": "1.1.0",
+  "Version": "1.1.1",
   "Description": "Order animals over the internet!",
   "UniqueID": "jwdred.MailOrderPigs",
   "EntryDll": "MailOrderPigs.dll",
-  "MinimumApiVersion": "2.6-beta",
+  "MinimumApiVersion": "2.8-beta",
   "UpdateKeys": [ "Nexus:632" ]
 }

--- a/MailOrderPigs/packages.config
+++ b/MailOrderPigs/packages.config
@@ -1,4 +1,0 @@
-﻿<?xml version="1.0" encoding="utf-8"?>
-<packages>
-  <package id="Pathoschild.Stardew.ModBuildConfig" version="2.1.0-beta-20180426" targetFramework="net452" />
-</packages>

--- a/PelicanFiber/Framework/ConstructionMenu.cs
+++ b/PelicanFiber/Framework/ConstructionMenu.cs
@@ -3,6 +3,7 @@ using System.Collections.Generic;
 using Microsoft.Xna.Framework;
 using Microsoft.Xna.Framework.Graphics;
 using Microsoft.Xna.Framework.Input;
+using StardewModdingAPI;
 using StardewValley;
 using StardewValley.BellsAndWhistles;
 using StardewValley.Buildings;
@@ -49,7 +50,6 @@ namespace PelicanFiber.Framework
 
         private BluePrint CurrentBlueprint => this.Blueprints[this.CurrentBlueprintIndex];
 
-
         /*********
         ** Public methods
         *********/
@@ -59,6 +59,7 @@ namespace PelicanFiber.Framework
             this.ShowMainMenu = showMainMenu;
 
             this.WhereToGo = Game1.player.currentLocation.Name;
+            
 
             Game1.player.forceCanMove();
             this.ResetBounds();
@@ -78,6 +79,13 @@ namespace PelicanFiber.Framework
                 this.Blueprints.Add(new BluePrint("Silo"));
                 this.Blueprints.Add(new BluePrint("Mill"));
                 this.Blueprints.Add(new BluePrint("Shed"));
+                int buildingsConstructed = Game1.getFarm().getNumberBuildingsConstructed("Cabin");
+                if (Game1.IsMasterGame)
+                {
+                    this.Blueprints.Add(new BluePrint("Stone Cabin"));
+                    this.Blueprints.Add(new BluePrint("Plank Cabin"));
+                    this.Blueprints.Add(new BluePrint("Log Cabin"));
+                }
                 if (!Game1.getFarm().isBuildingConstructed("Stable"))
                     this.Blueprints.Add(new BluePrint("Stable"));
                 this.Blueprints.Add(new BluePrint("Slime Hutch"));

--- a/PelicanFiber/Framework/ConstructionMenu.cs
+++ b/PelicanFiber/Framework/ConstructionMenu.cs
@@ -50,6 +50,7 @@ namespace PelicanFiber.Framework
 
         private BluePrint CurrentBlueprint => this.Blueprints[this.CurrentBlueprintIndex];
 
+
         /*********
         ** Public methods
         *********/

--- a/PelicanFiber/Framework/ItemUtils.cs
+++ b/PelicanFiber/Framework/ItemUtils.cs
@@ -371,32 +371,32 @@ namespace PelicanFiber.Framework
                 [new Object(219, 1)] = new[] { 250, int.MaxValue }
             };
 
-            if (Game1.player.fishingLevel >= 2 || unfiltered)
+            if (Game1.player.fishingLevel.Value >= 2 || unfiltered)
                 stock.Add(new Object(685, 1), new[] { 5, int.MaxValue });
-            if (Game1.player.fishingLevel >= 3 || unfiltered)
+            if (Game1.player.fishingLevel.Value >= 3 || unfiltered)
                 stock.Add(new Object(710, 1), new[] { 1500, int.MaxValue });
-            if (Game1.player.fishingLevel >= 6 || unfiltered)
+            if (Game1.player.fishingLevel.Value >= 6 || unfiltered)
             {
                 stock.Add(new Object(686, 1), new[] { 500, int.MaxValue });
                 stock.Add(new Object(694, 1), new[] { 500, int.MaxValue });
                 stock.Add(new Object(692, 1), new[] { 200, int.MaxValue });
             }
-            if (Game1.player.fishingLevel >= 7 || unfiltered)
+            if (Game1.player.fishingLevel.Value >= 7 || unfiltered)
             {
                 stock.Add(new Object(693, 1), new[] { 750, int.MaxValue });
                 stock.Add(new Object(695, 1), new[] { 750, int.MaxValue });
             }
-            if (Game1.player.fishingLevel >= 8 || unfiltered)
+            if (Game1.player.fishingLevel.Value >= 8 || unfiltered)
             {
                 stock.Add(new Object(691, 1), new[] { 1000, int.MaxValue });
                 stock.Add(new Object(687, 1), new[] { 1000, int.MaxValue });
             }
-            if (Game1.player.fishingLevel >= 9 || unfiltered)
+            if (Game1.player.fishingLevel.Value >= 9 || unfiltered)
                 stock.Add(new Object(703, 1), new[] { 1000, int.MaxValue });
             stock.Add(new FishingRod(0), new[] { 500, int.MaxValue });
-            if (Game1.player.fishingLevel >= 2 || unfiltered)
+            if (Game1.player.fishingLevel.Value >= 2 || unfiltered)
                 stock.Add(new FishingRod(2), new[] { 1800, int.MaxValue });
-            if (Game1.player.fishingLevel >= 6 || unfiltered)
+            if (Game1.player.fishingLevel.Value >= 6 || unfiltered)
                 stock.Add(new FishingRod(3), new[] { 7500, int.MaxValue });
 
             if (unfiltered)

--- a/PelicanFiber/PelicanFiber.cs
+++ b/PelicanFiber/PelicanFiber.cs
@@ -19,9 +19,6 @@ namespace PelicanFiber
         private bool Unfiltered = true;
         private ItemUtils ItemUtils;
 
-        //Instance so we can use Helper class
-        public static PelicanFiber instance;
-
 
         /*********
         ** Public methods
@@ -30,7 +27,6 @@ namespace PelicanFiber
         /// <param name="helper">Provides simplified APIs for writing mods.</param>
         public override void Entry(IModHelper helper)
         {
-            instance = this;
             // load config
             this.Config = this.Helper.ReadConfig<ModConfig>();
             if (!Enum.TryParse(this.Config.KeyBind, true, out this.MenuKey))

--- a/PelicanFiber/PelicanFiber.cs
+++ b/PelicanFiber/PelicanFiber.cs
@@ -19,6 +19,9 @@ namespace PelicanFiber
         private bool Unfiltered = true;
         private ItemUtils ItemUtils;
 
+        //Instance so we can use Helper class
+        public static PelicanFiber instance;
+
 
         /*********
         ** Public methods
@@ -27,6 +30,7 @@ namespace PelicanFiber
         /// <param name="helper">Provides simplified APIs for writing mods.</param>
         public override void Entry(IModHelper helper)
         {
+            instance = this;
             // load config
             this.Config = this.Helper.ReadConfig<ModConfig>();
             if (!Enum.TryParse(this.Config.KeyBind, true, out this.MenuKey))

--- a/PelicanFiber/PelicanFiber.csproj
+++ b/PelicanFiber/PelicanFiber.csproj
@@ -30,7 +30,7 @@
     <WarningLevel>4</WarningLevel>
   </PropertyGroup>
   <ItemGroup>
-    <PackageReference Include="Pathoschild.Stardew.ModBuildConfig" Version="2.1.0-beta-20180426" />
+    <PackageReference Include="Pathoschild.Stardew.ModBuildConfig" Version="2.2.0" />
   </ItemGroup>
   <ItemGroup>
     <Reference Include="System" />

--- a/PelicanFiber/PelicanFiber.csproj
+++ b/PelicanFiber/PelicanFiber.csproj
@@ -1,5 +1,5 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
-<Project ToolsVersion="14.0" DefaultTargets="Build" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
+<Project ToolsVersion="15.0" DefaultTargets="Build" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
   <Import Project="$(MSBuildExtensionsPath)\$(MSBuildToolsVersion)\Microsoft.Common.props" Condition="Exists('$(MSBuildExtensionsPath)\$(MSBuildToolsVersion)\Microsoft.Common.props')" />
   <PropertyGroup>
     <Configuration Condition=" '$(Configuration)' == '' ">Debug</Configuration>
@@ -30,6 +30,9 @@
     <WarningLevel>4</WarningLevel>
   </PropertyGroup>
   <ItemGroup>
+    <PackageReference Include="Pathoschild.Stardew.ModBuildConfig" Version="2.1.0-beta-20180426" />
+  </ItemGroup>
+  <ItemGroup>
     <Reference Include="System" />
     <Reference Include="System.Xml" />
   </ItemGroup>
@@ -52,18 +55,7 @@
       <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
     </None>
     <None Include="manifest.json" />
-    <None Include="packages.config" />
-  </ItemGroup>
-  <ItemGroup>
-    <Analyzer Include="..\packages\Pathoschild.Stardew.ModBuildConfig.2.1.0-beta-20180426\analyzers\dotnet\cs\StardewModdingAPI.ModBuildConfig.Analyzer.dll" />
   </ItemGroup>
   <Import Project="..\Common\Common.projitems" Label="Shared" />
   <Import Project="$(MSBuildToolsPath)\Microsoft.CSharp.targets" />
-  <Import Project="..\packages\Pathoschild.Stardew.ModBuildConfig.2.1.0-beta-20180426\build\Pathoschild.Stardew.ModBuildConfig.targets" Condition="Exists('..\packages\Pathoschild.Stardew.ModBuildConfig.2.1.0-beta-20180426\build\Pathoschild.Stardew.ModBuildConfig.targets')" />
-  <Target Name="EnsureNuGetPackageBuildImports" BeforeTargets="PrepareForBuild">
-    <PropertyGroup>
-      <ErrorText>This project references NuGet package(s) that are missing on this computer. Use NuGet Package Restore to download them.  For more information, see http://go.microsoft.com/fwlink/?LinkID=322105. The missing file is {0}.</ErrorText>
-    </PropertyGroup>
-    <Error Condition="!Exists('..\packages\Pathoschild.Stardew.ModBuildConfig.2.1.0-beta-20180426\build\Pathoschild.Stardew.ModBuildConfig.targets')" Text="$([System.String]::Format('$(ErrorText)', '..\packages\Pathoschild.Stardew.ModBuildConfig.2.1.0-beta-20180426\build\Pathoschild.Stardew.ModBuildConfig.targets'))" />
-  </Target>
 </Project>

--- a/PelicanFiber/manifest.json
+++ b/PelicanFiber/manifest.json
@@ -5,6 +5,6 @@
   "Description": "Order stuff over the internet, and save all kinds of money!",
   "UniqueID": "jwdred.PelicanFiber",
   "EntryDll": "PelicanFiber.dll",
-  "MinimumApiVersion": "2.6-beta",
+  "MinimumApiVersion": "2.8-beta",
   "UpdateKeys": [ "Nexus:631" ]
 }

--- a/PelicanFiber/manifest.json
+++ b/PelicanFiber/manifest.json
@@ -1,7 +1,7 @@
 ﻿{
   "Name": "PelicanFiber",
   "Author": "jwdred",
-  "Version": "3.1.1-unofficial.1.mizzion",
+  "Version": "3.1.1",
   "Description": "Order stuff over the internet, and save all kinds of money!",
   "UniqueID": "jwdred.PelicanFiber",
   "EntryDll": "PelicanFiber.dll",

--- a/PelicanFiber/manifest.json
+++ b/PelicanFiber/manifest.json
@@ -1,7 +1,7 @@
 ﻿{
   "Name": "PelicanFiber",
   "Author": "jwdred",
-  "Version": "3.1.0",
+  "Version": "3.1.1-unofficial.1.mizzion",
   "Description": "Order stuff over the internet, and save all kinds of money!",
   "UniqueID": "jwdred.PelicanFiber",
   "EntryDll": "PelicanFiber.dll",

--- a/PelicanFiber/packages.config
+++ b/PelicanFiber/packages.config
@@ -1,4 +1,0 @@
-﻿<?xml version="1.0" encoding="utf-8"?>
-<packages>
-  <package id="Pathoschild.Stardew.ModBuildConfig" version="2.1.0-beta-20180426" targetFramework="net452" />
-</packages>

--- a/PointAndPlant/PointAndPlant.csproj
+++ b/PointAndPlant/PointAndPlant.csproj
@@ -1,5 +1,5 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
-<Project ToolsVersion="14.0" DefaultTargets="Build" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
+<Project ToolsVersion="15.0" DefaultTargets="Build" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
   <Import Project="$(MSBuildExtensionsPath)\$(MSBuildToolsVersion)\Microsoft.Common.props" Condition="Exists('$(MSBuildExtensionsPath)\$(MSBuildToolsVersion)\Microsoft.Common.props')" />
   <PropertyGroup>
     <Configuration Condition=" '$(Configuration)' == '' ">Debug</Configuration>
@@ -30,6 +30,9 @@
     <WarningLevel>4</WarningLevel>
   </PropertyGroup>
   <ItemGroup>
+    <PackageReference Include="Pathoschild.Stardew.ModBuildConfig" Version="2.1.0-beta-20180426" />
+  </ItemGroup>
+  <ItemGroup>
     <Reference Include="System" />
     <Reference Include="System.Xml" />
   </ItemGroup>
@@ -41,17 +44,6 @@
   </ItemGroup>
   <ItemGroup>
     <None Include="manifest.json" />
-    <None Include="packages.config" />
-  </ItemGroup>
-  <ItemGroup>
-    <Analyzer Include="..\packages\Pathoschild.Stardew.ModBuildConfig.2.1.0-beta-20180426\analyzers\dotnet\cs\StardewModdingAPI.ModBuildConfig.Analyzer.dll" />
   </ItemGroup>
   <Import Project="$(MSBuildToolsPath)\Microsoft.CSharp.targets" />
-  <Import Project="..\packages\Pathoschild.Stardew.ModBuildConfig.2.1.0-beta-20180426\build\Pathoschild.Stardew.ModBuildConfig.targets" Condition="Exists('..\packages\Pathoschild.Stardew.ModBuildConfig.2.1.0-beta-20180426\build\Pathoschild.Stardew.ModBuildConfig.targets')" />
-  <Target Name="EnsureNuGetPackageBuildImports" BeforeTargets="PrepareForBuild">
-    <PropertyGroup>
-      <ErrorText>This project references NuGet package(s) that are missing on this computer. Use NuGet Package Restore to download them.  For more information, see http://go.microsoft.com/fwlink/?LinkID=322105. The missing file is {0}.</ErrorText>
-    </PropertyGroup>
-    <Error Condition="!Exists('..\packages\Pathoschild.Stardew.ModBuildConfig.2.1.0-beta-20180426\build\Pathoschild.Stardew.ModBuildConfig.targets')" Text="$([System.String]::Format('$(ErrorText)', '..\packages\Pathoschild.Stardew.ModBuildConfig.2.1.0-beta-20180426\build\Pathoschild.Stardew.ModBuildConfig.targets'))" />
-  </Target>
 </Project>

--- a/PointAndPlant/PointAndPlant.csproj
+++ b/PointAndPlant/PointAndPlant.csproj
@@ -30,7 +30,7 @@
     <WarningLevel>4</WarningLevel>
   </PropertyGroup>
   <ItemGroup>
-    <PackageReference Include="Pathoschild.Stardew.ModBuildConfig" Version="2.1.0-beta-20180426" />
+    <PackageReference Include="Pathoschild.Stardew.ModBuildConfig" Version="2.2.0" />
   </ItemGroup>
   <ItemGroup>
     <Reference Include="System" />

--- a/PointAndPlant/manifest.json
+++ b/PointAndPlant/manifest.json
@@ -1,10 +1,10 @@
 ﻿{
   "Name": "Point-and-Plant",
   "Author": "jwdred",
-  "Version": "1.1.0",
+  "Version": "1.1.1",
   "Description": "Plant and harvest from the comfort of your front porch!",
   "UniqueID": "jwdred.PointAndPlant",
   "EntryDll": "PointAndPlant.dll",
-  "MinimumApiVersion": "2.6-beta",
+  "MinimumApiVersion": "2.8-beta",
   "UpdateKeys": [ "Nexus:572" ]
 }

--- a/PointAndPlant/packages.config
+++ b/PointAndPlant/packages.config
@@ -1,4 +1,0 @@
-﻿<?xml version="1.0" encoding="utf-8"?>
-<packages>
-  <package id="Pathoschild.Stardew.ModBuildConfig" version="2.1.0-beta-20180426" targetFramework="net452" />
-</packages>

--- a/Replanter/Replanter.cs
+++ b/Replanter/Replanter.cs
@@ -884,9 +884,7 @@ namespace Replanter
 
             int rand = this.Random.Next(1, messageStore.Count + 1);
 
-            string value = "...$h#$e#";
-
-            messageStore.TryGetValue(rand, out value);
+            messageStore.TryGetValue(rand, out string value);
 
             return value;
         }

--- a/Replanter/Replanter.csproj
+++ b/Replanter/Replanter.csproj
@@ -30,7 +30,7 @@
     <WarningLevel>4</WarningLevel>
   </PropertyGroup>
   <ItemGroup>
-    <PackageReference Include="Pathoschild.Stardew.ModBuildConfig" Version="2.1.0-beta-20180426" />
+    <PackageReference Include="Pathoschild.Stardew.ModBuildConfig" Version="2.2.0" />
   </ItemGroup>
   <ItemGroup>
     <Reference Include="System" />

--- a/Replanter/Replanter.csproj
+++ b/Replanter/Replanter.csproj
@@ -1,5 +1,5 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
-<Project ToolsVersion="14.0" DefaultTargets="Build" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
+<Project ToolsVersion="15.0" DefaultTargets="Build" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
   <Import Project="$(MSBuildExtensionsPath)\$(MSBuildToolsVersion)\Microsoft.Common.props" Condition="Exists('$(MSBuildExtensionsPath)\$(MSBuildToolsVersion)\Microsoft.Common.props')" />
   <PropertyGroup>
     <Configuration Condition=" '$(Configuration)' == '' ">Debug</Configuration>
@@ -30,6 +30,9 @@
     <WarningLevel>4</WarningLevel>
   </PropertyGroup>
   <ItemGroup>
+    <PackageReference Include="Pathoschild.Stardew.ModBuildConfig" Version="2.1.0-beta-20180426" />
+  </ItemGroup>
+  <ItemGroup>
     <Reference Include="System" />
     <Reference Include="System.Xml" />
   </ItemGroup>
@@ -47,18 +50,7 @@
       <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
     </None>
     <None Include="manifest.json" />
-    <None Include="packages.config" />
-  </ItemGroup>
-  <ItemGroup>
-    <Analyzer Include="..\packages\Pathoschild.Stardew.ModBuildConfig.2.1.0-beta-20180426\analyzers\dotnet\cs\StardewModdingAPI.ModBuildConfig.Analyzer.dll" />
   </ItemGroup>
   <Import Project="..\Common\Common.projitems" Label="Shared" />
   <Import Project="$(MSBuildToolsPath)\Microsoft.CSharp.targets" />
-  <Import Project="..\packages\Pathoschild.Stardew.ModBuildConfig.2.1.0-beta-20180426\build\Pathoschild.Stardew.ModBuildConfig.targets" Condition="Exists('..\packages\Pathoschild.Stardew.ModBuildConfig.2.1.0-beta-20180426\build\Pathoschild.Stardew.ModBuildConfig.targets')" />
-  <Target Name="EnsureNuGetPackageBuildImports" BeforeTargets="PrepareForBuild">
-    <PropertyGroup>
-      <ErrorText>This project references NuGet package(s) that are missing on this computer. Use NuGet Package Restore to download them.  For more information, see http://go.microsoft.com/fwlink/?LinkID=322105. The missing file is {0}.</ErrorText>
-    </PropertyGroup>
-    <Error Condition="!Exists('..\packages\Pathoschild.Stardew.ModBuildConfig.2.1.0-beta-20180426\build\Pathoschild.Stardew.ModBuildConfig.targets')" Text="$([System.String]::Format('$(ErrorText)', '..\packages\Pathoschild.Stardew.ModBuildConfig.2.1.0-beta-20180426\build\Pathoschild.Stardew.ModBuildConfig.targets'))" />
-  </Target>
 </Project>

--- a/Replanter/manifest.json
+++ b/Replanter/manifest.json
@@ -1,10 +1,10 @@
 ﻿{
   "Name": "Replanter",
   "Author": "jwdred",
-  "Version": "1.1.0",
+  "Version": "1.1.1",
   "Description": "Harvest and replant fields that are ready.",
   "UniqueID": "jwdred.Replanter",
   "EntryDll": "Replanter.dll",
-  "MinimumApiVersion": "2.6-beta",
+  "MinimumApiVersion": "2.8-beta",
   "UpdateKeys": [ "Nexus:589" ]
 }

--- a/Replanter/packages.config
+++ b/Replanter/packages.config
@@ -1,4 +1,0 @@
-﻿<?xml version="1.0" encoding="utf-8"?>
-<packages>
-  <package id="Pathoschild.Stardew.ModBuildConfig" version="2.1.0-beta-20180426" targetFramework="net452" />
-</packages>

--- a/SortMyStuff/SortMyStuff.csproj
+++ b/SortMyStuff/SortMyStuff.csproj
@@ -1,5 +1,5 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
-<Project ToolsVersion="14.0" DefaultTargets="Build" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
+<Project ToolsVersion="15.0" DefaultTargets="Build" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
   <Import Project="$(MSBuildExtensionsPath)\$(MSBuildToolsVersion)\Microsoft.Common.props" Condition="Exists('$(MSBuildExtensionsPath)\$(MSBuildToolsVersion)\Microsoft.Common.props')" />
   <PropertyGroup>
     <Configuration Condition=" '$(Configuration)' == '' ">Debug</Configuration>
@@ -30,6 +30,9 @@
     <WarningLevel>4</WarningLevel>
   </PropertyGroup>
   <ItemGroup>
+    <PackageReference Include="Pathoschild.Stardew.ModBuildConfig" Version="2.1.0-beta-20180426" />
+  </ItemGroup>
+  <ItemGroup>
     <Reference Include="System" />
     <Reference Include="System.Xml" />
   </ItemGroup>
@@ -41,18 +44,7 @@
   </ItemGroup>
   <ItemGroup>
     <None Include="manifest.json" />
-    <None Include="packages.config" />
-  </ItemGroup>
-  <ItemGroup>
-    <Analyzer Include="..\packages\Pathoschild.Stardew.ModBuildConfig.2.1.0-beta-20180426\analyzers\dotnet\cs\StardewModdingAPI.ModBuildConfig.Analyzer.dll" />
   </ItemGroup>
   <Import Project="..\Common\Common.projitems" Label="Shared" />
   <Import Project="$(MSBuildToolsPath)\Microsoft.CSharp.targets" />
-  <Import Project="..\packages\Pathoschild.Stardew.ModBuildConfig.2.1.0-beta-20180426\build\Pathoschild.Stardew.ModBuildConfig.targets" Condition="Exists('..\packages\Pathoschild.Stardew.ModBuildConfig.2.1.0-beta-20180426\build\Pathoschild.Stardew.ModBuildConfig.targets')" />
-  <Target Name="EnsureNuGetPackageBuildImports" BeforeTargets="PrepareForBuild">
-    <PropertyGroup>
-      <ErrorText>This project references NuGet package(s) that are missing on this computer. Use NuGet Package Restore to download them.  For more information, see http://go.microsoft.com/fwlink/?LinkID=322105. The missing file is {0}.</ErrorText>
-    </PropertyGroup>
-    <Error Condition="!Exists('..\packages\Pathoschild.Stardew.ModBuildConfig.2.1.0-beta-20180426\build\Pathoschild.Stardew.ModBuildConfig.targets')" Text="$([System.String]::Format('$(ErrorText)', '..\packages\Pathoschild.Stardew.ModBuildConfig.2.1.0-beta-20180426\build\Pathoschild.Stardew.ModBuildConfig.targets'))" />
-  </Target>
 </Project>

--- a/SortMyStuff/SortMyStuff.csproj
+++ b/SortMyStuff/SortMyStuff.csproj
@@ -30,7 +30,7 @@
     <WarningLevel>4</WarningLevel>
   </PropertyGroup>
   <ItemGroup>
-    <PackageReference Include="Pathoschild.Stardew.ModBuildConfig" Version="2.1.0-beta-20180426" />
+    <PackageReference Include="Pathoschild.Stardew.ModBuildConfig" Version="2.2.0" />
   </ItemGroup>
   <ItemGroup>
     <Reference Include="System" />

--- a/SortMyStuff/manifest.json
+++ b/SortMyStuff/manifest.json
@@ -5,6 +5,6 @@
   "Description": "Sorts your items into chests at the press of a button.",
   "UniqueID": "jwdred.SortMyStuff",
   "EntryDll": "SortMyStuff.dll",
-  "MinimumApiVersion": "2.6-beta",
+  "MinimumApiVersion": "2.8-beta",
   "UpdateKeys": []
 }

--- a/SortMyStuff/packages.config
+++ b/SortMyStuff/packages.config
@@ -1,4 +1,0 @@
-﻿<?xml version="1.0" encoding="utf-8"?>
-<packages>
-  <package id="Pathoschild.Stardew.ModBuildConfig" version="2.1.0-beta-20180426" targetFramework="net452" />
-</packages>


### PR DESCRIPTION
This pull request...

* Adds [cabins](https://stardewvalleywiki.com/Cabin) to Pelican Fiber (thanks to @Mizzion in #5!).
* Migrates to the newer NuGet package reference format.
* Updates to the latest mod build config package.
* Performs minor cleanup (inlined out variables).
* Bumps manifest versions for release.

If the changes look fine, can you deploy these updates? The mods are broken in both Stardew Valley 1.3.28 and 1.3.31-beta, but the latter will be out of beta soon so these builds are for that version.

mod | update
--- | ------
[Animal Sitter](https://www.nexusmods.com/stardewvalley/mods/581) | [1.1.1.zip](https://github.com/jdusbabek/stardewvalley/files/2560410/AnimalSitter.1.1.1.zip)
[Crab Net](https://www.nexusmods.com/stardewvalley/mods/584) | [1.1.1.zip](https://github.com/jdusbabek/stardewvalley/files/2560412/CrabNet.1.1.1.zip)
[Mail Order Pigs](https://www.nexusmods.com/stardewvalley/mods/632) | [1.1.1.zip](https://github.com/jdusbabek/stardewvalley/files/2560413/MailOrderPigs.1.1.1.zip)
[Pelican Fiber](https://www.nexusmods.com/stardewvalley/mods/631) | [3.1.1.zip](https://github.com/jdusbabek/stardewvalley/files/2560438/PelicanFiber.3.1.1.zip)
[Point and Plant](https://www.nexusmods.com/stardewvalley/mods/572) | [1.1.1.zip](https://github.com/jdusbabek/stardewvalley/files/2560415/PointAndPlant.1.1.1.zip)
[Replanter](https://www.nexusmods.com/stardewvalley/mods/589) | [1.1.1.zip](https://github.com/jdusbabek/stardewvalley/files/2560416/Replanter.1.1.1.zip)
