### PR TITLE
Fixes for most in-person/online shop disparities

### DIFF
--- a/PelicanFiber/Framework/ItemUtils.cs
+++ b/PelicanFiber/Framework/ItemUtils.cs
@@ -1,4 +1,4 @@
-﻿using System;
+using System;
 using System.Collections.Generic;
 using System.Linq;
 using Microsoft.Xna.Framework;
@@ -46,9 +46,9 @@ namespace PelicanFiber.Framework
                         new Object(Vector2.Zero, 474, int.MaxValue),
                         new Object(Vector2.Zero, 475, int.MaxValue),
                         new Object(Vector2.Zero, 427, int.MaxValue),
-                        new Object(Vector2.Zero, 477, int.MaxValue)
+                        new Object(Vector2.Zero, 477, int.MaxValue),
                         new Object(Vector2.Zero, 429, int.MaxValue),
-                        new Object(745, int.MaxValue, false, 100),
+                        new Object(745, int.MaxValue, false, 100)
                     });
                     if (Game1.year > 1 || unfiltered)
                     {
@@ -97,7 +97,7 @@ namespace PelicanFiber.Framework
 
                 stock.Add(new Object(Vector2.Zero, 297, int.MaxValue));
                 if (!Game1.player.craftingRecipes.ContainsKey("Grass Starter"))
-                    stock.Add(new Object(297, 1, true, -1, 0), new[] { 1000, 1 });
+                    stock.Add(new Object(297, 1, true, 1000, 0));
                 stock.AddRange(new[]
                 {
                     new Object(628, int.MaxValue, false, 1700),
@@ -114,15 +114,15 @@ namespace PelicanFiber.Framework
                 });
                 if ((int) Game1.stats.DaysPlayed >= 15)
                 {
-                    stock.Add(368, int.MaxValue, false, 50);
-                    stock.Add(370, int.MaxValue, false, 50);
-                    stock.Add(465, int.MaxValue, false, 50);
+                    stock.Add(new Object(368, int.MaxValue, false, 50));
+                    stock.Add(new Object(370, int.MaxValue, false, 50));
+                    stock.Add(new Object(465, int.MaxValue, false, 50));
                 }
                 if (Game1.year > 1)
                 {
-                    stock.Add(369, int.MaxValue, false, 75);
-                    stock.Add(371, int.MaxValue, false, 75);
-                    stock.Add(466, int.MaxValue, false, 75);
+                    stock.Add(new Object(369, int.MaxValue, false, 75));
+                    stock.Add(new Object(371, int.MaxValue, false, 75));
+                    stock.Add(new Object(466, int.MaxValue, false, 75));
                 }
 
                 Random random = new Random((int)Game1.stats.DaysPlayed + (int)Game1.uniqueIDForThisGame / 2);
@@ -134,16 +134,15 @@ namespace PelicanFiber.Framework
                     new Wallpaper(which) { Stack = int.MaxValue },
                     new Wallpaper(random.Next(56), true) { Stack = int.MaxValue }
                 });
-                stock.Add(new Clothing(1000 + random.Next(128)), new[] { 1000, int.MaxValue });
-                stock.Add(new Furniture(1308, Vector2.Zero));
-                if (Game1.player.achievements.Contains(38))
+                stock.Add(new Furniture(1308, Vector2.Zero) { Stack = int.MaxValue });
+                if (Game1.player.hasAFriendWithHeartLevel(8, true))
                     stock.Add(new Object(Vector2.Zero, 458, int.MaxValue));
             }
             else
             {
                 stock.AddRange(new[]
                 {
-                    new Object(Vector2.Zero, 802, int.MaxValue),
+                    new Object(Vector2.Zero, 802, int.MaxValue) { Price = 75 },
                     new Object(Vector2.Zero, 478, int.MaxValue),
                     new Object(Vector2.Zero, 486, int.MaxValue),
                     new Object(Vector2.Zero, 494, int.MaxValue),
@@ -189,7 +188,7 @@ namespace PelicanFiber.Framework
                             break;                            
                     }
                 }
-                stock.Add(new Clothing(1000 + new Random((int) Game1.stats.DaysPlayed + (int) Game1.uniqueIDForThisGame / 2).Next((int) sbyte.MaxValue)), new[] { 1000, int.MaxValue });
+                stock.Add(new Clothing(1000 + new Random((int)Game1.stats.DaysPlayed + (int)Game1.uniqueIDForThisGame / 2).Next((int)sbyte.MaxValue)) { Price = 1000, Stack = int.MaxValue });
             }
             return stock;
         }
@@ -203,99 +202,99 @@ namespace PelicanFiber.Framework
             {
                 new Object(Vector2.Zero, 388, int.MaxValue),
                 new Object(Vector2.Zero, 390, int.MaxValue),
-                new Furniture(1614, Vector2.Zero),
-                new Furniture(1616, Vector2.Zero),
-                new Workbench(Vector2.Zero)
+                new Furniture(1614, Vector2.Zero) { Stack = int.MaxValue },
+                new Furniture(1616, Vector2.Zero) { Stack = int.MaxValue },
+                new Workbench(Vector2.Zero) { Stack = int.MaxValue }
             };
             if (Game1.currentSeason == "winter" || Game1.year >= 2 || unfiltered)
-                stock.Add(new WoodChipper(Vector2.Zero));
+                stock.Add(new WoodChipper(Vector2.Zero) { Stack = int.MaxValue });
             if (Utility.getHomeOfFarmer(Game1.player).upgradeLevel > 0 || unfiltered)
-                stock.Add(new Object(Vector2.Zero, 216, false));
+                stock.Add(new Object(Vector2.Zero, 216, false) { Stack = int.MaxValue });
 
-            if (unfiltered)
-            {
-                stock.AddRange(this.GetAllFurniture());
-            }
-            else
-            {
-                switch (Game1.dayOfMonth % 7)
-                {
-                    case 0:
-                        stock.Add(this.GetRandomFurniture(r, stock, 1296, 1391));
-                        stock.Add(this.GetRandomFurniture(r, stock, 416, 537));
-                        break;
-                    case 1:
-                        stock.AddRange(new[]
-                        {
-                            new Furniture(0, Vector2.Zero),
-                            new Furniture(192, Vector2.Zero),
-                            new Furniture(704, Vector2.Zero),
-                            new Furniture(1120, Vector2.Zero),
-                            new Furniture(1216, Vector2.Zero),
-                            new Furniture(1391, Vector2.Zero)
-                        });
-                        break;
-                    case 2:
-                        stock.AddRange(new[]
-                        {
-                            new Furniture(3, Vector2.Zero),
-                            new Furniture(197, Vector2.Zero),
-                            new Furniture(709, Vector2.Zero),
-                            new Furniture(1122, Vector2.Zero),
-                            new Furniture(1218, Vector2.Zero),
-                            new Furniture(1393, Vector2.Zero)
-                        });
-                        break;
-                    case 3:
-                        stock.AddRange(new[]
-                        {
-                            new Furniture(6, Vector2.Zero),
-                            new Furniture(202, Vector2.Zero),
-                            new Furniture(714, Vector2.Zero),
-                            new Furniture(1124, Vector2.Zero),
-                            new Furniture(1220, Vector2.Zero),
-                            new Furniture(1395, Vector2.Zero)
-                        });
-                        break;
-                    case 4:
-                        stock.AddRange(new[]
-                        {
-                            this.GetRandomFurniture(r, stock, 1296, 1391),
-                            this.GetRandomFurniture(r, stock, 1296, 1391)
-                        });
-                        break;
-                    case 5:
-                        stock.AddRange(new[]
-                        {
-                            this.GetRandomFurniture(r, stock, 1443, 1450),
-                            this.GetRandomFurniture(r, stock, 288, 313)
-                        });
-                        break;
-                    case 6:
-                        stock.AddRange(new[]
-                        {
-                            this.GetRandomFurniture(r, stock, 1565, 1607),
-                            this.GetRandomFurniture(r, stock, 12, 129)
-                        });
-                        break;
-                }
-                stock.Add(this.GetRandomFurniture(r, stock, 0, 1462));
-                stock.Add(this.GetRandomFurniture(r, stock, 0, 1462));
-                while (r.NextDouble() < 0.25)
-                    stock.Add(this.GetRandomFurniture(r, stock, 1673, 1815));
-                stock.Add(new Furniture(1402, Vector2.Zero));
-                stock.Add(new TV(1466, Vector2.Zero));
-                stock.Add(new TV(1680, Vector2.Zero));
+			if (unfiltered)
+			{
+				stock.AddRange(this.GetAllFurniture());
+			}
+			else
+			{
+				switch (Game1.dayOfMonth % 7)
+				{
+					case 0:
+						stock.Add(this.GetRandomFurniture(r, stock, 1296, 1391));
+						stock.Add(this.GetRandomFurniture(r, stock, 416, 537));
+						break;
+					case 1:
+						stock.AddRange(new[]
+						{
+							new Furniture(0, Vector2.Zero) { Stack = int.MaxValue },
+							new Furniture(192, Vector2.Zero) { Stack = int.MaxValue },
+							new Furniture(704, Vector2.Zero) { Stack = int.MaxValue },
+							new Furniture(1120, Vector2.Zero) { Stack = int.MaxValue },
+							new Furniture(1216, Vector2.Zero) { Stack = int.MaxValue },
+							new Furniture(1391, Vector2.Zero) { Stack = int.MaxValue }
+						});
+						break;
+					case 2:
+						stock.AddRange(new[]
+						{
+							new Furniture(3, Vector2.Zero) { Stack = int.MaxValue },
+							new Furniture(197, Vector2.Zero) { Stack = int.MaxValue },
+							new Furniture(709, Vector2.Zero) { Stack = int.MaxValue },
+							new Furniture(1122, Vector2.Zero) { Stack = int.MaxValue },
+							new Furniture(1218, Vector2.Zero) { Stack = int.MaxValue },
+							new Furniture(1393, Vector2.Zero) { Stack = int.MaxValue }
+						});
+						break;
+					case 3:
+						stock.AddRange(new[]
+						{
+							new Furniture(6, Vector2.Zero) { Stack = int.MaxValue },
+							new Furniture(202, Vector2.Zero) { Stack = int.MaxValue },
+							new Furniture(714, Vector2.Zero) { Stack = int.MaxValue },
+							new Furniture(1124, Vector2.Zero) { Stack = int.MaxValue },
+							new Furniture(1220, Vector2.Zero) { Stack = int.MaxValue },
+							new Furniture(1395, Vector2.Zero) { Stack = int.MaxValue }
+						});
+						break;
+					case 4:
+						stock.AddRange(new[]
+						{
+							this.GetRandomFurniture(r, stock, 1296, 1391),
+							this.GetRandomFurniture(r, stock, 1296, 1391)
+						});
+						break;
+					case 5:
+						stock.AddRange(new[]
+						{
+							this.GetRandomFurniture(r, stock, 1443, 1450),
+							this.GetRandomFurniture(r, stock, 288, 313)
+						});
+						break;
+					case 6:
+						stock.AddRange(new[]
+						{
+							this.GetRandomFurniture(r, stock, 1565, 1607),
+							this.GetRandomFurniture(r, stock, 12, 129)
+						});
+						break;
+				}
+				stock.Add(this.GetRandomFurniture(r, stock, 0, 1462));
+				stock.Add(this.GetRandomFurniture(r, stock, 0, 1462));
+				while (r.NextDouble() < 0.25)
+					stock.Add(this.GetRandomFurniture(r, stock, 1673, 1815));
+				stock.Add(new Furniture(1402, Vector2.Zero) { Stack = int.MaxValue });
+				stock.Add(new TV(1466, Vector2.Zero) { Stack = int.MaxValue });
+				stock.Add(new TV(1680, Vector2.Zero) { Stack = int.MaxValue });
+				if (Utility.getHomeOfFarmer(Game1.player).upgradeLevel > 0)
+					stock.Add(new TV(1468, Vector2.Zero) { Stack = int.MaxValue });
                 if (Utility.getHomeOfFarmer(Game1.player).upgradeLevel > 0)
-                    stock.Add(new TV(1468, Vector2.Zero));
-                if (Utility.getHomeOfFarmer(Game1.player).upgradeLevel > 0)
-                    stock.Add(new Furniture(1226, Vector2.Zero));
+                    stock.Add(new Furniture(1226, Vector2.Zero) { Stack = int.MaxValue });
                 stock.Add(new Object(Vector2.Zero, 200, false) { Stack = int.MaxValue });
                 stock.Add(new Object(Vector2.Zero, 35, false) { Stack = int.MaxValue });
                 stock.Add(new Object(Vector2.Zero, 46, false) { Stack = int.MaxValue });
-                stock.Add(new Furniture(1792, Vector2.Zero));
-                stock.Add(new Furniture(1794, Vector2.Zero));
-                stock.Add(new Furniture(1798, Vector2.Zero));
+                stock.Add(new Furniture(1792, Vector2.Zero) { Stack = int.MaxValue });
+                stock.Add(new Furniture(1794, Vector2.Zero) { Stack = int.MaxValue });
+                stock.Add(new Furniture(1798, Vector2.Zero) { Stack = int.MaxValue });
             }
 
             if (!Game1.player.craftingRecipes.ContainsKey("Wooden Brazier"))
@@ -345,39 +344,117 @@ namespace PelicanFiber.Framework
 
 
         private bool IsFurnitureOffLimitsForSale(int index)
-        {
-            switch (index)
-            {
-                case 1669:
-                case 1671:
-                case 1680:
-                case 1733:
-                case 1541:
-                case 1545:
-                case 1554:
-                case 1298:
-                case 1299:
-                case 1300:
-                case 1301:
-                case 1302:
-                case 1303:
-                case 1304:
-                case 1305:
-                case 1306:
-                case 1307:
-                case 1308:
-                case 1402:
-                case 1466:
-                case 1468:
-                case 131:
-                case 1226:
-                    return true;
-                default:
-                    return false;
-            }
-        }
+		{
+			if (index <= 1545)
+			{
+				if (index <= 1375)
+				{
+					if (index <= 989)
+					{
+						if (index != 131 && (uint)(index - 984) > 2U && index != 989)
+							goto label_22;
+					}
+					else if (index != 1226 && (uint)(index - 1298) > 11U)
+					{
+						switch (index)
+						{
+							case 1371:
+							case 1373:
+							case 1375:
+								break;
+							default:
+								goto label_22;
+						}
+					}
+				}
+				else if (index <= 1468)
+				{
+					if (index != 1402 && index != 1466 && index != 1468)
+						goto label_22;
+				}
+				else if (index != 1471 && index != 1541 && index != 1545)
+					goto label_22;
+			}
+			else if (index <= 1764)
+			{
+				if (index <= 1671)
+				{
+					if (index != 1554 && index != 1669 && index != 1671)
+						goto label_22;
+				}
+				else if (index != 1680 && index != 1733 && (uint)(index - 1760) > 4U)
+					goto label_22;
+			}
+			else if (index <= 1900)
+			{
+				switch (index - 1796)
+				{
+					case 0:
+					case 2:
+					case 4:
+					case 6:
+						break;
+					case 1:
+					case 3:
+					case 5:
+						goto label_22;
+					default:
+						switch (index - 1838)
+						{
+							case 0:
+							case 2:
+							case 4:
+							case 6:
+							case 8:
+							case 10:
+							case 12:
+							case 14:
+							case 16:
+								break;
+							case 1:
+							case 3:
+							case 5:
+							case 7:
+							case 9:
+							case 11:
+							case 13:
+							case 15:
+								goto label_22;
+							default:
+								if (index == 1900)
+									break;
+								goto label_22;
+						}
+						break;
+				}
+			}
+			else if (index <= 1918)
+			{
+				if (index != 1902)
+				{
+					switch (index - 1907)
+					{
+						case 0:
+						case 2:
+						case 7:
+						case 8:
+						case 9:
+						case 10:
+						case 11:
+							break;
+						default:
+							goto label_22;
+					}
+				}
+			}
+			else if ((uint)(index - 1952) > 9U && index != 1971)
+				goto label_22;
+			return true;
+			label_22:
+			return false;
+		}
 
-        private List<Item> GetAllFurniture()
+		private List<Item> GetAllFurniture()
         {
             List<Item> list = new List<Item>();
 
@@ -476,7 +553,7 @@ namespace PelicanFiber.Framework
                 stock.Add(new FishingRod(2), new[] { 1800, int.MaxValue });
             if (Game1.player.fishingLevel.Value >= 6 || unfiltered)
                 stock.Add(new FishingRod(3), new[] { 7500, int.MaxValue });
-            if (Game1.masterPlayer.mailReceived.Contains("ccFishTank"))
+            if (Game1.MasterPlayer.mailReceived.Contains("ccFishTank"))
                 stock.Add(new Pan(), new[] { 2500, int.MaxValue });
 
             if (unfiltered)

--- a/PelicanFiber/Framework/ItemUtils.cs
+++ b/PelicanFiber/Framework/ItemUtils.cs
@@ -46,27 +46,31 @@ namespace PelicanFiber.Framework
                         new Object(Vector2.Zero, 474, int.MaxValue),
                         new Object(Vector2.Zero, 475, int.MaxValue),
                         new Object(Vector2.Zero, 427, int.MaxValue),
+                        new Object(Vector2.Zero, 477, int.MaxValue)
                         new Object(Vector2.Zero, 429, int.MaxValue),
                         new Object(745, int.MaxValue, false, 100),
-                        new Object(Vector2.Zero, 477, int.MaxValue),
-                        new Object(Vector2.Zero, 273, int.MaxValue)
                     });
                     if (Game1.year > 1 || unfiltered)
+                    {
                         stock.Add(new Object(Vector2.Zero, 476, int.MaxValue));
+                        stock.Add(new Object(Vector2.Zero, 273, int.MaxValue));
+                    }
                 }
                 if (Game1.currentSeason.Equals("summer") || unfiltered)
                 {
                     stock.AddRange(new[]
                     {
+                        new Object(Vector2.Zero, 479, int.MaxValue),
                         new Object(Vector2.Zero, 480, int.MaxValue),
                         new Object(Vector2.Zero, 481, int.MaxValue),
                         new Object(Vector2.Zero, 482, int.MaxValue),
                         new Object(Vector2.Zero, 483, int.MaxValue),
                         new Object(Vector2.Zero, 484, int.MaxValue),
-                        new Object(Vector2.Zero, 479, int.MaxValue),
-                        new Object(Vector2.Zero, 302, int.MaxValue),
                         new Object(Vector2.Zero, 453, int.MaxValue),
-                        new Object(Vector2.Zero, 455, int.MaxValue)
+                        new Object(Vector2.Zero, 455, int.MaxValue),
+                        new Object(Vector2.Zero, 302, int.MaxValue),
+                        new Object(Vector2.Zero, 487, int.MaxValue),
+                        new Object(431, int.MaxValue, false, 100)
                     });
                     if (Game1.year > 1 || unfiltered)
                         stock.Add(new Object(Vector2.Zero, 485, int.MaxValue));
@@ -75,21 +79,25 @@ namespace PelicanFiber.Framework
                 {
                     stock.AddRange(new[]
                     {
+                        new Object(Vector2.Zero, 490, int.MaxValue),
                         new Object(Vector2.Zero, 487, int.MaxValue),
                         new Object(Vector2.Zero, 488, int.MaxValue),
-                        new Object(Vector2.Zero, 490, int.MaxValue),
-                        new Object(Vector2.Zero, 299, int.MaxValue),
-                        new Object(Vector2.Zero, 301, int.MaxValue),
-                        new Object(Vector2.Zero, 492, int.MaxValue),
                         new Object(Vector2.Zero, 491, int.MaxValue),
+                        new Object(Vector2.Zero, 492, int.MaxValue),
                         new Object(Vector2.Zero, 493, int.MaxValue),
+                        new Object(Vector2.Zero, 483, int.MaxValue),
                         new Object(431, int.MaxValue, false, 100),
-                        new Object(Vector2.Zero, 425, int.MaxValue)
+                        new Object(Vector2.Zero, 425, int.MaxValue),
+                        new Object(Vector2.Zero, 299, int.MaxValue),
+                        new Object(Vector2.Zero, 301, int.MaxValue)
                     });
                     if (Game1.year > 1 || unfiltered)
                         stock.Add(new Object(Vector2.Zero, 489, int.MaxValue));
                 }
 
+                stock.Add(new Object(Vector2.Zero, 297, int.MaxValue));
+                if (!Game1.player.craftingRecipes.ContainsKey("Grass Starter"))
+                    stock.Add(new Object(297, 1, true, -1, 0), new[] { 1000, 1 });
                 stock.AddRange(new[]
                 {
                     new Object(628, int.MaxValue, false, 1700),
@@ -98,19 +106,36 @@ namespace PelicanFiber.Framework
                     new Object(631, int.MaxValue, false, 3000),
                     new Object(632, int.MaxValue, false, 3000),
                     new Object(633, int.MaxValue, false, 2000),
-                    new Object(Vector2.Zero, 297, int.MaxValue),
                     new Object(Vector2.Zero, 245, int.MaxValue),
                     new Object(Vector2.Zero, 246, int.MaxValue),
                     new Object(Vector2.Zero, 423, int.MaxValue),
                     new Object(Vector2.Zero, 247, int.MaxValue),
+                    new Object(Vector2.Zero, 419, int.MaxValue)
                 });
+                if ((int) Game1.stats.DaysPlayed >= 15)
+                {
+                    stock.Add(368, int.MaxValue, false, 50);
+                    stock.Add(370, int.MaxValue, false, 50);
+                    stock.Add(465, int.MaxValue, false, 50);
+                }
+                if (Game1.year > 1)
+                {
+                    stock.Add(369, int.MaxValue, false, 75);
+                    stock.Add(371, int.MaxValue, false, 75);
+                    stock.Add(466, int.MaxValue, false, 75);
+                }
 
                 Random random = new Random((int)Game1.stats.DaysPlayed + (int)Game1.uniqueIDForThisGame / 2);
+                int which = random.Next(112);
+                if (which == 21)
+                    which = 36;
                 stock.AddRange(new[]
                 {
-                    new Wallpaper(random.Next(112)) { Stack = int.MaxValue },
-                    new Wallpaper(random.Next(40), true) { Stack = int.MaxValue }
+                    new Wallpaper(which) { Stack = int.MaxValue },
+                    new Wallpaper(random.Next(56), true) { Stack = int.MaxValue }
                 });
+                stock.Add(new Clothing(1000 + random.Next(128)), new[] { 1000, int.MaxValue });
+                stock.Add(new Furniture(1308, Vector2.Zero));
                 if (Game1.player.achievements.Contains(38))
                     stock.Add(new Object(Vector2.Zero, 458, int.MaxValue));
             }
@@ -122,7 +147,7 @@ namespace PelicanFiber.Framework
                     new Object(Vector2.Zero, 478, int.MaxValue),
                     new Object(Vector2.Zero, 486, int.MaxValue),
                     new Object(Vector2.Zero, 494, int.MaxValue),
-                    new Object(Vector2.Zero, 196, false)
+                    new Object(Vector2.Zero, 196, false) { Stack = int.MaxValue }
                 });
                 if (unfiltered)
                 {
@@ -164,7 +189,7 @@ namespace PelicanFiber.Framework
                             break;                            
                     }
                 }
-                stock.Add(new Clothing(1000 + new Random((int) Game1.stats.DaysPlayed + (int) Game1.uniqueIDForThisGame / 2).Next((int) sbyte.MaxValue)), 1000, int.MaxValue);
+                stock.Add(new Clothing(1000 + new Random((int) Game1.stats.DaysPlayed + (int) Game1.uniqueIDForThisGame / 2).Next((int) sbyte.MaxValue)), new[] { 1000, int.MaxValue });
             }
             return stock;
         }
@@ -180,10 +205,12 @@ namespace PelicanFiber.Framework
                 new Object(Vector2.Zero, 390, int.MaxValue),
                 new Furniture(1614, Vector2.Zero),
                 new Furniture(1616, Vector2.Zero),
-                new Workbench(Vector2.Zero),
-                new WoodChipper(Vector2.Zero),
-                new Object(Vector2.Zero, 216, false)
+                new Workbench(Vector2.Zero)
             };
+            if (Game1.currentSeason == "winter" || Game1.year >= 2 || unfiltered)
+                stock.Add(new WoodChipper(Vector2.Zero));
+            if (Utility.getHomeOfFarmer(Game1.player).upgradeLevel > 0 || unfiltered)
+                stock.Add(new Object(Vector2.Zero, 216, false));
 
             if (unfiltered)
             {
@@ -252,8 +279,8 @@ namespace PelicanFiber.Framework
                         });
                         break;
                 }
-                stock.Add(this.GetRandomFurniture(r, stock));
-                stock.Add(this.GetRandomFurniture(r, stock));
+                stock.Add(this.GetRandomFurniture(r, stock, 0, 1462));
+                stock.Add(this.GetRandomFurniture(r, stock, 0, 1462));
                 while (r.NextDouble() < 0.25)
                     stock.Add(this.GetRandomFurniture(r, stock, 1673, 1815));
                 stock.Add(new Furniture(1402, Vector2.Zero));
@@ -263,9 +290,9 @@ namespace PelicanFiber.Framework
                     stock.Add(new TV(1468, Vector2.Zero));
                 if (Utility.getHomeOfFarmer(Game1.player).upgradeLevel > 0)
                     stock.Add(new Furniture(1226, Vector2.Zero));
-                stock.Add(new Object(Vector2.Zero, 200, false));
-                stock.Add(new Object(Vector2.Zero, 35, false));
-                stock.Add(new Object(Vector2.Zero, 46, false));
+                stock.Add(new Object(Vector2.Zero, 200, false) { Stack = int.MaxValue });
+                stock.Add(new Object(Vector2.Zero, 35, false) { Stack = int.MaxValue });
+                stock.Add(new Object(Vector2.Zero, 46, false) { Stack = int.MaxValue });
                 stock.Add(new Furniture(1792, Vector2.Zero));
                 stock.Add(new Furniture(1794, Vector2.Zero));
                 stock.Add(new Furniture(1798, Vector2.Zero));
@@ -444,10 +471,13 @@ namespace PelicanFiber.Framework
             if (Game1.player.fishingLevel.Value >= 9 || unfiltered)
                 stock.Add(new Object(703, 1), new[] { 1000, int.MaxValue });
             stock.Add(new FishingRod(0), new[] { 500, int.MaxValue });
+            stock.Add(new FishingRod(1), new[] { 25, int.MaxValue });
             if (Game1.player.fishingLevel.Value >= 2 || unfiltered)
                 stock.Add(new FishingRod(2), new[] { 1800, int.MaxValue });
             if (Game1.player.fishingLevel.Value >= 6 || unfiltered)
                 stock.Add(new FishingRod(3), new[] { 7500, int.MaxValue });
+            if (Game1.masterPlayer.mailReceived.Contains("ccFishTank"))
+                stock.Add(new Pan(), new[] { 2500, int.MaxValue });
 
             if (unfiltered)
             {
@@ -479,7 +509,7 @@ namespace PelicanFiber.Framework
             };
 
             if (Game1.dishOfTheDay.Stack > 0 && !unfiltered)
-                stock.Add(Game1.dishOfTheDay);
+                stock.Add(Game1.dishOfTheDay.getOne() as Object);
             else if (unfiltered)
             {
                 // 194 - 239
@@ -506,7 +536,13 @@ namespace PelicanFiber.Framework
                 stock.Add(new Object(206, 1, true, 75));
             if (!Game1.player.cookingRecipes.ContainsKey("Maki Roll"))
                 stock.Add(new Object(228, 1, true, 150));
-
+            if (!Game1.player.cookingRecipes.ContainsKey("Cookies") && Game1.player.eventsSeen.Contains(19))
+                stock.Add(new Object(223, 1, true, 150) { name = "Cookies" });
+            if (!Game1.player.cookingRecipes.ContainsKey("Triple Shot Espresso"))
+                stock.Add(new Object(253, 1, true, 2500));
+            if (Game1.player.activeDialogueEvents.ContainsKey("willyCrabs"))
+                stock.Add(new Object(Vector2.Zero, 732, int.MaxValue));
+            
             return stock;
         }
 

--- a/PelicanFiber/Framework/ItemUtils.cs
+++ b/PelicanFiber/Framework/ItemUtils.cs
@@ -616,7 +616,7 @@ namespace PelicanFiber.Framework
             if (!Game1.player.cookingRecipes.ContainsKey("Cookies") && Game1.player.eventsSeen.Contains(19))
                 stock.Add(new Object(223, 1, true, 150) { name = "Cookies" });
             if (!Game1.player.cookingRecipes.ContainsKey("Triple Shot Espresso"))
-                stock.Add(new Object(253, 1, true, 2500));
+                stock.Add(new Object(253, 1, true, 500));
             if (Game1.player.activeDialogueEvents.ContainsKey("willyCrabs"))
                 stock.Add(new Object(Vector2.Zero, 732, int.MaxValue));
             

--- a/PelicanFiber/Framework/ItemUtils.cs
+++ b/PelicanFiber/Framework/ItemUtils.cs
@@ -49,8 +49,7 @@ namespace PelicanFiber.Framework
                         new Object(Vector2.Zero, 429, int.MaxValue),
                         new Object(745, int.MaxValue, false, 100),
                         new Object(Vector2.Zero, 477, int.MaxValue),
-                        new Object(628, int.MaxValue, false, 1700),
-                        new Object(629, int.MaxValue, false, 1000)
+                        new Object(Vector2.Zero, 273, int.MaxValue)
                     });
                     if (Game1.year > 1 || unfiltered)
                         stock.Add(new Object(Vector2.Zero, 476, int.MaxValue));
@@ -60,15 +59,14 @@ namespace PelicanFiber.Framework
                     stock.AddRange(new[]
                     {
                         new Object(Vector2.Zero, 480, int.MaxValue),
+                        new Object(Vector2.Zero, 481, int.MaxValue),
                         new Object(Vector2.Zero, 482, int.MaxValue),
                         new Object(Vector2.Zero, 483, int.MaxValue),
                         new Object(Vector2.Zero, 484, int.MaxValue),
                         new Object(Vector2.Zero, 479, int.MaxValue),
                         new Object(Vector2.Zero, 302, int.MaxValue),
                         new Object(Vector2.Zero, 453, int.MaxValue),
-                        new Object(Vector2.Zero, 455, int.MaxValue),
-                        new Object(630, int.MaxValue, false, 2000),
-                        new Object(631, int.MaxValue, false, 3000)
+                        new Object(Vector2.Zero, 455, int.MaxValue)
                     });
                     if (Game1.year > 1 || unfiltered)
                         stock.Add(new Object(Vector2.Zero, 485, int.MaxValue));
@@ -86,9 +84,7 @@ namespace PelicanFiber.Framework
                         new Object(Vector2.Zero, 491, int.MaxValue),
                         new Object(Vector2.Zero, 493, int.MaxValue),
                         new Object(431, int.MaxValue, false, 100),
-                        new Object(Vector2.Zero, 425, int.MaxValue),
-                        new Object(632, int.MaxValue, false, 3000),
-                        new Object(633, int.MaxValue, false, 2000)
+                        new Object(Vector2.Zero, 425, int.MaxValue)
                     });
                     if (Game1.year > 1 || unfiltered)
                         stock.Add(new Object(Vector2.Zero, 489, int.MaxValue));
@@ -96,10 +92,17 @@ namespace PelicanFiber.Framework
 
                 stock.AddRange(new[]
                 {
+                    new Object(628, int.MaxValue, false, 1700),
+                    new Object(629, int.MaxValue, false, 1000),
+                    new Object(630, int.MaxValue, false, 2000),
+                    new Object(631, int.MaxValue, false, 3000),
+                    new Object(632, int.MaxValue, false, 3000),
+                    new Object(633, int.MaxValue, false, 2000),
                     new Object(Vector2.Zero, 297, int.MaxValue),
                     new Object(Vector2.Zero, 245, int.MaxValue),
                     new Object(Vector2.Zero, 246, int.MaxValue),
-                    new Object(Vector2.Zero, 423, int.MaxValue)
+                    new Object(Vector2.Zero, 423, int.MaxValue),
+                    new Object(Vector2.Zero, 247, int.MaxValue),
                 });
 
                 Random random = new Random((int)Game1.stats.DaysPlayed + (int)Game1.uniqueIDForThisGame / 2);
@@ -113,20 +116,53 @@ namespace PelicanFiber.Framework
             }
             else
             {
-                if (Game1.currentSeason.Equals("spring") || unfiltered)
-                    stock.Add(new Object(Vector2.Zero, 478, int.MaxValue));
-                if (Game1.currentSeason.Equals("summer") || unfiltered)
+                stock.AddRange(new[]
                 {
-                    stock.Add(new Object(Vector2.Zero, 486, int.MaxValue));
-                    stock.Add(new Object(Vector2.Zero, 481, int.MaxValue));
-                }
-                if (Game1.currentSeason.Equals("fall") || unfiltered)
+                    new Object(Vector2.Zero, 802, int.MaxValue),
+                    new Object(Vector2.Zero, 478, int.MaxValue),
+                    new Object(Vector2.Zero, 486, int.MaxValue),
+                    new Object(Vector2.Zero, 494, int.MaxValue)  
+                });
+                if (unfiltered)
                 {
-                    stock.Add(new Object(Vector2.Zero, 493, int.MaxValue));
-                    stock.Add(new Object(Vector2.Zero, 494, int.MaxValue));
+                    stock.AddRange(new[]
+                    {
+                        new Object(Vector2.Zero, 88, int.MaxValue),
+                        new Object(Vector2.Zero, 90, int.MaxValue),
+                        new Object(Vector2.Zero, 749, int.MaxValue),
+                        new Object(Vector2.Zero, 466, int.MaxValue),
+                        new Object(Vector2.Zero, 340, int.MaxValue),
+                        new Object(Vector2.Zero, 371, int.MaxValue),
+                        new Object(Vector2.Zero, 233, int.MaxValue)
+                    });
                 }
-                stock.Add(new Object(Vector2.Zero, 88, int.MaxValue));
-                stock.Add(new Object(Vector2.Zero, 90, int.MaxValue));
+                else
+                {
+                    switch (Game1.dayOfMonth % 7)
+                    {
+                        case 0:
+                            stock.Add(new Object(Vector2.Zero, 233, int.MaxValue));
+                            break;
+                        case 1:
+                            stock.Add(new Object(Vector2.Zero, 88, int.MaxValue));
+                            break;
+                        case 2:
+                            stock.Add(new Object(Vector2.Zero, 90, int.MaxValue));
+                            break;
+                        case 3:
+                            stock.Add(new Object(Vector2.Zero, 749, int.MaxValue));
+                            break;
+                        case 4:
+                            stock.Add(new Object(Vector2.Zero, 466, int.MaxValue));
+                            break;
+                        case 5:
+                            stock.Add(new Object(Vector2.Zero, 340, int.MaxValue));
+                            break;
+                        case 6:
+                            stock.Add(new Object(Vector2.Zero, 371, int.MaxValue));
+                            break;                            
+                    }
+                }
             }
             return stock;
         }
@@ -141,7 +177,10 @@ namespace PelicanFiber.Framework
                 new Object(Vector2.Zero, 388, int.MaxValue),
                 new Object(Vector2.Zero, 390, int.MaxValue),
                 new Furniture(1614, Vector2.Zero),
-                new Furniture(1616, Vector2.Zero)
+                new Furniture(1616, Vector2.Zero),
+                new Workbench(Vector2.Zero),
+                new WoodChipper(Vector2.Zero),
+                new Object(Vector2.Zero, 216, false)
             };
 
             if (unfiltered)
@@ -258,6 +297,8 @@ namespace PelicanFiber.Framework
                 stock.Add(new Object(328, 1, true, 50));
             if (!Game1.player.craftingRecipes.ContainsKey("Stone Floor"))
                 stock.Add(new Object(329, 1, true, 50));
+            if (!Game1.player.craftingRecipes.ContainsKey("Brick Floor"))
+                stock.Add(new Object(293, 1, true, 50));
             if (!Game1.player.craftingRecipes.ContainsKey("Stepping Stone Path"))
                 stock.Add(new Object(415, 1, true, 50));
             if (!Game1.player.craftingRecipes.ContainsKey("Straw Floor"))

--- a/PelicanFiber/Framework/ItemUtils.cs
+++ b/PelicanFiber/Framework/ItemUtils.cs
@@ -121,7 +121,8 @@ namespace PelicanFiber.Framework
                     new Object(Vector2.Zero, 802, int.MaxValue),
                     new Object(Vector2.Zero, 478, int.MaxValue),
                     new Object(Vector2.Zero, 486, int.MaxValue),
-                    new Object(Vector2.Zero, 494, int.MaxValue)  
+                    new Object(Vector2.Zero, 494, int.MaxValue),
+                    new Object(Vector2.Zero, 196, false)
                 });
                 if (unfiltered)
                 {
@@ -163,6 +164,7 @@ namespace PelicanFiber.Framework
                             break;                            
                     }
                 }
+                stock.Add(new Clothing(1000 + new Random((int) Game1.stats.DaysPlayed + (int) Game1.uniqueIDForThisGame / 2).Next((int) sbyte.MaxValue)), 1000, int.MaxValue);
             }
             return stock;
         }
@@ -261,6 +263,12 @@ namespace PelicanFiber.Framework
                     stock.Add(new TV(1468, Vector2.Zero));
                 if (Utility.getHomeOfFarmer(Game1.player).upgradeLevel > 0)
                     stock.Add(new Furniture(1226, Vector2.Zero));
+                stock.Add(new Object(Vector2.Zero, 200, false));
+                stock.Add(new Object(Vector2.Zero, 35, false));
+                stock.Add(new Object(Vector2.Zero, 46, false));
+                stock.Add(new Furniture(1792, Vector2.Zero));
+                stock.Add(new Furniture(1794, Vector2.Zero));
+                stock.Add(new Furniture(1798, Vector2.Zero));
             }
 
             if (!Game1.player.craftingRecipes.ContainsKey("Wooden Brazier"))

--- a/PelicanFiber/Framework/PelicanFiberMenu.cs
+++ b/PelicanFiber/Framework/PelicanFiberMenu.cs
@@ -250,7 +250,7 @@ namespace PelicanFiber.Framework
 
                 SpriteText.drawStringHorizontallyCenteredAt(b, "Dwarf", (int)(this.xPositionOnScreen + 182 * this.Scale), (int)(this.yPositionOnScreen + 1167 * this.Scale), 999999, -1, 999999, 1, 0.88f, false, 1);
                 SpriteText.drawStringHorizontallyCenteredAt(b, "Qi", (int)(this.xPositionOnScreen + 448 * this.Scale), (int)(this.yPositionOnScreen + 1167 * this.Scale), 999999, -1, 999999, 1, 0.88f, false, 1);
-                SpriteText.drawStringHorizontallyCenteredAt(b, "Oaisis", (int)(this.xPositionOnScreen + 714 * this.Scale), (int)(this.yPositionOnScreen + 1167 * this.Scale), 999999, -1, 999999, 1, 0.88f, false, 1);
+                SpriteText.drawStringHorizontallyCenteredAt(b, "Oasis", (int)(this.xPositionOnScreen + 714 * this.Scale), (int)(this.yPositionOnScreen + 1167 * this.Scale), 999999, -1, 999999, 1, 0.88f, false, 1);
                 SpriteText.drawStringHorizontallyCenteredAt(b, "Joja", (int)(this.xPositionOnScreen + 980 * this.Scale), (int)(this.yPositionOnScreen + 1167 * this.Scale), 999999, -1, 999999, 1, 0.88f, false, 1);
 
                 SpriteText.drawStringHorizontallyCenteredAt(b, "Foraged", (int)(this.xPositionOnScreen + 1246 * this.Scale), (int)(this.yPositionOnScreen + 997 * this.Scale), 999999, -1, 999999, 1, 0.88f, false, 1);

--- a/PelicanFiber/Framework/PelicanFiberMenu.cs
+++ b/PelicanFiber/Framework/PelicanFiberMenu.cs
@@ -1,4 +1,4 @@
-﻿using System;
+using System;
 using System.Collections.Generic;
 using System.Diagnostics.CodeAnalysis;
 using Microsoft.Xna.Framework;
@@ -286,7 +286,7 @@ namespace PelicanFiber.Framework
 
                 SpriteText.drawStringHorizontallyCenteredAt(b, "Dwarf", (int)(this.xPositionOnScreen + 180 * this.Scale), (int)(this.yPositionOnScreen + 1165 * this.Scale), 999999, -1, 999999, 1, 0.88f, false, 4);
                 SpriteText.drawStringHorizontallyCenteredAt(b, "Qi", (int)(this.xPositionOnScreen + 448 * this.Scale), (int)(this.yPositionOnScreen + 1165 * this.Scale), 999999, -1, 999999, 1, 0.88f, false, 4);
-                SpriteText.drawStringHorizontallyCenteredAt(b, "Oaisis", (int)(this.xPositionOnScreen + 714 * this.Scale), (int)(this.yPositionOnScreen + 1165 * this.Scale), 999999, -1, 999999, 1, 0.88f, false, 4);
+                SpriteText.drawStringHorizontallyCenteredAt(b, "Oasis", (int)(this.xPositionOnScreen + 714 * this.Scale), (int)(this.yPositionOnScreen + 1165 * this.Scale), 999999, -1, 999999, 1, 0.88f, false, 4);
                 SpriteText.drawStringHorizontallyCenteredAt(b, "Joja", (int)(this.xPositionOnScreen + 980 * this.Scale), (int)(this.yPositionOnScreen + 1165 * this.Scale), 999999, -1, 999999, 1, 0.88f, false, 4);
 
                 SpriteText.drawStringHorizontallyCenteredAt(b, "Foraged", (int)(this.xPositionOnScreen + 1244 * this.Scale), (int)(this.yPositionOnScreen + 995 * this.Scale), 999999, -1, 999999, 1, 0.88f, false, 4);
@@ -370,55 +370,62 @@ namespace PelicanFiber.Framework
             Dictionary<ISalable, int[]> itemPriceAndStock = new Dictionary<ISalable, int[]>();
             int maxValue = int.MaxValue;
             itemPriceAndStock.Add(new MeleeWeapon(12), new[] { 250, maxValue });
-            if (Game1.mine != null)
+            if (MineShaft.lowestLevelReached >= 15)
+                itemPriceAndStock.Add(new MeleeWeapon(17), new[] { 500, maxValue });
+            if (MineShaft.lowestLevelReached >= 20)
+                itemPriceAndStock.Add(new MeleeWeapon(1), new[] { 750, maxValue });
+            if (MineShaft.lowestLevelReached >= 25)
             {
-                if (MineShaft.lowestLevelReached >= 15)
-                    itemPriceAndStock.Add(new MeleeWeapon(17), new[] { 500, maxValue });
-                if (MineShaft.lowestLevelReached >= 20)
-                    itemPriceAndStock.Add(new MeleeWeapon(1), new[] { 750, maxValue });
-                if (MineShaft.lowestLevelReached >= 25)
-                {
-                    itemPriceAndStock.Add(new MeleeWeapon(43), new[] { 850, maxValue });
-                    itemPriceAndStock.Add(new MeleeWeapon(44), new[] { 1500, maxValue });
-                }
-                if (MineShaft.lowestLevelReached >= 40)
-                    itemPriceAndStock.Add(new MeleeWeapon(27), new[] { 2000, maxValue });
-                if (MineShaft.lowestLevelReached >= 45)
-                    itemPriceAndStock.Add(new MeleeWeapon(10), new[] { 2000, maxValue });
-                if (MineShaft.lowestLevelReached >= 55)
-                    itemPriceAndStock.Add(new MeleeWeapon(7), new[] { 4000, maxValue });
-                if (MineShaft.lowestLevelReached >= 75)
-                    itemPriceAndStock.Add(new MeleeWeapon(5), new[] { 6000, maxValue });
-                if (MineShaft.lowestLevelReached >= 90)
-                    itemPriceAndStock.Add(new MeleeWeapon(50), new[] { 9000, maxValue });
-                if (MineShaft.lowestLevelReached >= 120)
-                    itemPriceAndStock.Add(new MeleeWeapon(9), new[] { 25000, maxValue });
-                if (Game1.player.mailReceived.Contains("galaxySword"))
-                {
-                    itemPriceAndStock.Add(new MeleeWeapon(4), new[] { 50000, maxValue });
-                    itemPriceAndStock.Add(new MeleeWeapon(23), new[] { 350000, maxValue });
-                    itemPriceAndStock.Add(new MeleeWeapon(29), new[] { 75000, maxValue });
-                }
+                itemPriceAndStock.Add(new MeleeWeapon(43), new[] { 850, maxValue });
+                itemPriceAndStock.Add(new MeleeWeapon(44), new[] { 1500, maxValue });
             }
+            if (MineShaft.lowestLevelReached >= 40)
+                itemPriceAndStock.Add(new MeleeWeapon(27), new[] { 2000, maxValue });
+            if (MineShaft.lowestLevelReached >= 45)
+                itemPriceAndStock.Add(new MeleeWeapon(10), new[] { 2000, maxValue });
+            if (MineShaft.lowestLevelReached >= 55)
+                itemPriceAndStock.Add(new MeleeWeapon(7), new[] { 4000, maxValue });
+            if (MineShaft.lowestLevelReached >= 75)
+                itemPriceAndStock.Add(new MeleeWeapon(5), new[] { 6000, maxValue });
+            if (MineShaft.lowestLevelReached >= 90)
+                itemPriceAndStock.Add(new MeleeWeapon(50), new[] { 9000, maxValue });
+            if (MineShaft.lowestLevelReached >= 120)
+                itemPriceAndStock.Add(new MeleeWeapon(9), new[] { 25000, maxValue });
+            if (Game1.player.mailReceived.Contains("galaxySword"))
+            {
+                itemPriceAndStock.Add(new MeleeWeapon(4), new[] { 50000, maxValue });
+                itemPriceAndStock.Add(new MeleeWeapon(23), new[] { 350000, maxValue });
+                itemPriceAndStock.Add(new MeleeWeapon(29), new[] { 75000, maxValue });
+            }
+        
             itemPriceAndStock.Add(new Boots(504), new[] { 500, maxValue });
-            if (Game1.mine != null && MineShaft.lowestLevelReached >= 40)
+			if (MineShaft.lowestLevelReached >= 10)
+				itemPriceAndStock.Add(new Boots(506), new[] { 500, maxValue });
+            if (MineShaft.lowestLevelReached >= 40)
                 itemPriceAndStock.Add(new Boots(508), new[] { 1250, maxValue });
-            if (Game1.mine != null && MineShaft.lowestLevelReached >= 80)
-                itemPriceAndStock.Add(new Boots(511), new[] { 2500, maxValue });
+			if (MineShaft.lowestLevelReached >= 50)
+				itemPriceAndStock.Add(new Boots(509), new[] { 750, maxValue });
+			if (MineShaft.lowestLevelReached >= 80)
+			{
+				itemPriceAndStock.Add(new Boots(512), new[] { 2000, maxValue });
+				itemPriceAndStock.Add(new Boots(511), new[] { 2500, maxValue });
+			}
+			if (MineShaft.lowestLevelReached >= 110)
+				itemPriceAndStock.Add(new Boots(514), new[] { 5000, maxValue });
             itemPriceAndStock.Add(new Ring(529), new[] { 1000, maxValue });
             itemPriceAndStock.Add(new Ring(530), new[] { 1000, maxValue });
-            if (Game1.mine != null && MineShaft.lowestLevelReached >= 40)
+            if (MineShaft.lowestLevelReached >= 40)
             {
                 itemPriceAndStock.Add(new Ring(531), new[] { 2500, maxValue });
                 itemPriceAndStock.Add(new Ring(532), new[] { 2500, maxValue });
             }
-            if (Game1.mine != null && MineShaft.lowestLevelReached >= 80)
+            if (MineShaft.lowestLevelReached >= 80)
             {
                 itemPriceAndStock.Add(new Ring(533), new[] { 5000, maxValue });
                 itemPriceAndStock.Add(new Ring(534), new[] { 5000, maxValue });
             }
-            if (Game1.player.hasItemWithNameThatContains("Slingshot") != null)
-                itemPriceAndStock.Add(new Object(441, int.MaxValue), new[] { 100, maxValue });
+			if (Game1.player.craftingRecipes.ContainsKey("Explosive Ammo"))
+				itemPriceAndStock.Add(new Object(441, int.MaxValue), new[] { 300, maxValue });
             if (Game1.player.mailReceived.Contains("Gil_Slime Charmer Ring"))
                 itemPriceAndStock.Add(new Ring(520), new[] { 25000, maxValue });
             if (Game1.player.mailReceived.Contains("Gil_Savage Ring"))
@@ -427,10 +434,18 @@ namespace PelicanFiber.Framework
                 itemPriceAndStock.Add(new Ring(526), new[] { 20000, maxValue });
             if (Game1.player.mailReceived.Contains("Gil_Vampire Ring"))
                 itemPriceAndStock.Add(new Ring(522), new[] { 15000, maxValue });
+			if (Game1.player.mailReceived.Contains("Gil_Crabshell Ring"))
+				itemPriceAndStock.Add(new Ring(810), new[] { 15000, maxValue });
+			if (Game1.player.mailReceived.Contains("Gil_Napalm Ring"))
+				itemPriceAndStock.Add(new Ring(811), new[] { 30000, maxValue });
             if (Game1.player.mailReceived.Contains("Gil_Skeleton Mask"))
                 itemPriceAndStock.Add(new Hat(8), new[] { 20000, maxValue });
             if (Game1.player.mailReceived.Contains("Gil_Hard Hat"))
                 itemPriceAndStock.Add(new Hat(27), new[] { 20000, maxValue });
+			if (Game1.player.mailReceived.Contains("Gil_Arcane Hat"))
+				itemPriceAndStock.Add(new Hat(60), new[] { 20000, maxValue });
+			if (Game1.player.mailReceived.Contains("Gil_Knight's Helmet"))
+				itemPriceAndStock.Add(new Hat(50), new[] { 20000, maxValue });
             if (Game1.player.mailReceived.Contains("Gil_Insect Head"))
                 itemPriceAndStock.Add(new MeleeWeapon(13), new[] { 10000, maxValue });
             //Game1.activeClickableMenu = (IClickableMenu)new ShopMenu(itemPriceAndStock, 0, "Marlon");

--- a/PelicanFiber/manifest.json
+++ b/PelicanFiber/manifest.json
@@ -1,7 +1,7 @@
 ﻿{
   "Name": "PelicanFiber",
   "Author": "jwdred",
-  "Version": "3.1.2-unofficial.1-NateMcCloud",
+  "Version": "3.1.1-unofficial.10-NateMcCloud",
   "Description": "Order stuff over the internet, and save all kinds of money!",
   "UniqueID": "jwdred.PelicanFiber",
   "EntryDll": "PelicanFiber.dll",

--- a/PelicanFiber/manifest.json
+++ b/PelicanFiber/manifest.json
@@ -1,7 +1,7 @@
 ﻿{
   "Name": "PelicanFiber",
   "Author": "jwdred",
-  "Version": "3.1.1",
+  "Version": "3.1.2-unofficial.1-NateMcCloud",
   "Description": "Order stuff over the internet, and save all kinds of money!",
   "UniqueID": "jwdred.PelicanFiber",
   "EntryDll": "PelicanFiber.dll",


### PR DESCRIPTION
Proposed update to make website stocks more closely match actual stocks.

Everything sold on the websites now match the in-store stock, with the exceptions of the player-sold items in Pierre's and Willy's stores, and possibly the dish of the day at the Saloon.